### PR TITLE
修改admin_id为user_id解决前台重复登录问题

### DIFF
--- a/controller/admin/admin.js
+++ b/controller/admin/admin.js
@@ -373,7 +373,7 @@ class Admin extends BaseClass {
   //获取用户信息
   async userInfo(req, res, next) {
     try {
-      let user_info = await AdminModel.findOne({id: req.session.admin_id}, 'username id avatar status create_time');
+      let user_info = await AdminModel.findOne({id: req.session.user_id}, 'username id avatar status create_time');
       res.send({
         status: 200,
         data: user_info,


### PR DESCRIPTION
获取用户信息函数中，修改AdminModel.findOne({id: req.session.user_id}的admin_id为user_id